### PR TITLE
fix(users-list): ensure users list fills full container width

### DIFF
--- a/src/components/UsersList.vue
+++ b/src/components/UsersList.vue
@@ -60,6 +60,7 @@
 <style lang="scss" scoped>
 	.users-list {
 		max-width: 85rem;
+		width:100%;
 		margin: 0 auto;
 		padding: 0;
 		display: flex;


### PR DESCRIPTION
# fix(users-list): ensure users list fills full container width

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | XS | 12-04-2026 | 09-05-2026 |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [ ] New feature
- [ ] Improvement
- [ ] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

Fix the users list container to fill the full available width, ensuring the user cards grid displays correctly without gaps on the sides.

## 📋 Changes Made

- Add `width: 100%` to `.users-list` class in `UsersList.vue` to ensure the flex container occupies the entire parent width

## 🧪 Tests

- [x] Test Manual testing performed

## 🔗 References

### Files to modify
- `UsersList.vue`