### PR TITLE
feat(map): display map on right side of user card unless mobile

### DIFF
--- a/src/components/UserMap.vue
+++ b/src/components/UserMap.vue
@@ -41,8 +41,6 @@
 <style lang="scss" scoped>
 	.user-map {
 		width: 100%;
-		height: 50rem;
-		margin-top: 5rem;
 
 		@include media('sm') {
 			height: 30rem;

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -6,11 +6,11 @@
 					v-if="user"
 					:user="user"
 				/>
+				<UserMap
+					v-if="user"
+					:user="user"
+				/>
 			</div>
-			<UserMap
-				v-if="user"
-				:user="user"
-			/>
 		</section>
 	</div>
 </template>
@@ -49,4 +49,17 @@
 	};
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.inner::v-deep {
+	display: flex;
+
+	@include media('lg') {
+		flex-wrap: wrap;
+
+		.user-map {
+			margin-top: 3rem;
+			height: 50rem;
+		}
+	}
+}
+</style>


### PR DESCRIPTION
# feat(map): display map on right side of user card unless mobile

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | S | 12-04-2026 | 09-05-2026 |

## 🔄 Type of Change

- [ ] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [x] New feature
- [ ] Improvement
- [ ] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

Move the map component to display on the right side of the user detail card on desktop, and below the card on mobile devices.

## 📋 Changes Made

### Improvements
- Move `UserMap` component inside the `.inner` wrapper in `User.vue`
- Add flexbox layout to `.inner` container for side-by-side display
- Add responsive wrapping with `flex-wrap` for large screens
- Remove fixed `height` and `margin-top` from `.user-map` in `UserMap.vue`

## 🧪 Tests

- [x] Test Manual testing performed
- [x] Verify responsive behavior on mobile and desktop

## 🔗 References

### Related Issues
- Closes #125