### PR TITLE
fix(layout): change `rem` to `vh` units

### DIFF
--- a/src/components/UserDetail.vue
+++ b/src/components/UserDetail.vue
@@ -118,43 +118,43 @@
 
 <style lang="scss" scoped>
 	.user-detail {
-		max-width: 60rem;
+		max-width: 60vh;
 		margin: 0 auto;
-		padding: 4rem;
-		font-size: 2.4rem;
+		padding: 4vh;
+		font-size: 2vh;
 		color: $color-light;
 		background-color: $color-brand-2;
 
 		@include media('sm') {
-			padding: 3rem;
-			font-size: 2rem;
+			padding: 3vh;
+			font-size: 2vh;
 		}
 
 		&__group {
 			&:not(:last-child) {
-				margin-bottom: 2rem;
+				margin-bottom: 2vh;
 
 				@include media('sm') {
-					margin-bottom: 1rem;
+					margin-bottom: 1vh;
 				}
 			}
 		}
 
 		&__image {
-			width: 15rem;
-			height: 15rem;
-			margin-bottom: 4rem;
+			width: 15vh;
+			height: 15vh;
+			margin-bottom: 4vh;
 			display: flex;
 			justify-content: center;
 			align-items: center;
 			border-radius: 50%;
-			border: 0.3rem solid $color-white;
+			border: 0.3vh solid $color-white;
 			overflow: hidden;
 
 			@include media('sm') {
-				width: 10rem;
-				height: 10rem;
-				margin-bottom: 2rem;
+				width: 10vh;
+				height: 10vh;
+				margin-bottom: 2vh;
 			}
 
 			img {

--- a/src/components/UserMap.vue
+++ b/src/components/UserMap.vue
@@ -43,8 +43,8 @@
 		width: 100%;
 
 		@include media('sm') {
-			height: 30rem;
-			margin-top: 3rem;
+			height: 30vh;
+			margin-top: 3vh;
 		}
 	}
 </style>

--- a/src/components/UserMap.vue
+++ b/src/components/UserMap.vue
@@ -41,8 +41,6 @@
 <style lang="scss" scoped>
 	.user-map {
 		width: 100%;
-		height: 50rem;
-		margin-top: 5rem;
 
 		@include media('sm') {
 			height: 30rem;

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -6,11 +6,11 @@
 					v-if="user"
 					:user="user"
 				/>
+				<UserMap
+					v-if="user"
+					:user="user"
+				/>
 			</div>
-			<UserMap
-				v-if="user"
-				:user="user"
-			/>
 		</section>
 	</div>
 </template>
@@ -49,4 +49,17 @@
 	};
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.inner::v-deep {
+	display: flex;
+
+	@include media('lg') {
+		flex-wrap: wrap;
+
+		.user-map {
+			margin-top: 3rem;
+			height: 50rem;
+		}
+	}
+}
+</style>


### PR DESCRIPTION
# fix(layout): change `rem` to `vh` units

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | S | 12-10-2021 | 09-05-2026 |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [ ] New feature
- [ ] Improvement
- [ ] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

Replace `rem` units with `vh` units in user detail and map components for improved viewport-based scaling.

## 📋 Changes Made

### Bug Fixes
- Replace `rem` units with `vh` in `UserDetail.vue` (padding, font-size, margin, image dimensions, border)
- Replace `rem` units with `vh` in `UserMap.vue` (height, margin)
- Move `UserMap` component inside the `.inner` wrapper in `User.vue`
- Add flexbox layout to `.inner` container with responsive wrapping

## 🧪 Tests

- [x] Test Manual testing performed

## 🔗 References

### Related Issues
- Closes #125