### PR TITLE
hotfix(3.1.2): fix page reload losing user data with `Local Storage`

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,7 @@
 		<main class="page-main">
 			<page-title />
 
-			<router-view :usersFetch="users" />
+			<router-view :usersFetch="getUsers" />
 		</main>
 	</div>
 </template>
@@ -25,14 +25,19 @@
 		},
 		data() {
 			return {
-				users: []
+				usersList: []
 			}
 		},
 		created() {
 			this.setUsers();
 		},
+		computed: {
+			getUsers() {
+				return this.usersList;
+			}
+		},
 		methods: {
-			async getUsers() {
+			async fetchUsers() {
 				const response = await fetch('https://randomuser.me/api/?results=10');
 				const data = await response.json();
 
@@ -64,9 +69,9 @@
 				return users;
 			},
 			async setUsers() {
-				const data = await this.getUsers();
+				const data = await this.fetchUsers();
 				const usersFormatted = await this.createUsers(data);
-				this.users = usersFormatted;
+				this.usersList = usersFormatted;
 			}
 		},
 		watch: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,8 +62,7 @@
 						cell: user.cell,
 						email: user.email,
 						imageMedium: user.picture.medium,
-						imageLarge: user.picture.large,
-						selected: false
+						imageLarge: user.picture.large
 					}
 				));
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -63,6 +63,7 @@
 						email: user.email,
 						imageMedium: user.picture.medium,
 						imageLarge: user.picture.large,
+						selected: false
 					}
 				));
 
@@ -82,8 +83,7 @@
 			},
 			removeLocalStorage(key) {
 				localStorage.removeItem(key);
-			},
-
+			}
 		},
 		watch: {
 			$route: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,7 +29,7 @@
 			}
 		},
 		created() {
-			this.setUsers();
+			this.checkUsers();
 		},
 		computed: {
 			getUsers() {
@@ -75,6 +75,16 @@
 				this.usersList = usersFormatted;
 				this.setLocalStorage('users', this.usersList);
 			},
+			checkUsers() {
+				if (this.getLocalStorage("users")) {
+					this.updatedUsers();
+				} else {
+					this.setUsers();
+				}
+			},
+			updatedUsers() {
+				this.usersList = this.getLocalStorage("users");
+			},
 			getLocalStorage(key) {
 				return JSON.parse(localStorage.getItem(key));
 			},
@@ -97,13 +107,6 @@
 					html.classList.add('page', 'page-' + to.name.toLowerCase());
 					body.classList.add('page-body');
 				},
-				immediate: true,
-			},
-			usersList: {
-				handler(newValue) {
-					this.setLocalStorage('users', newValue);
-				},
-				deep: true,
 				immediate: true,
 			}
 		},

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,13 +29,17 @@
 			}
 		},
 		created() {
-			this.getUsers();
+			this.setUsers();
 		},
 		methods: {
 			async getUsers() {
 				const response = await fetch('https://randomuser.me/api/?results=10');
 				const data = await response.json();
-				this.users = data.results.map(user => (
+
+				return data;
+			},
+			async createUsers(data) {
+				const users = data.results.map(user => (
 					{
 						name: user.name,
 						username: user.login.username,
@@ -56,6 +60,13 @@
 						imageLarge: user.picture.large,
 					}
 				));
+
+				return users;
+			},
+			async setUsers() {
+				const data = await this.getUsers();
+				const usersFormatted = await this.createUsers(data);
+				this.users = usersFormatted;
 			}
 		},
 		watch: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -72,7 +72,18 @@
 				const data = await this.fetchUsers();
 				const usersFormatted = await this.createUsers(data);
 				this.usersList = usersFormatted;
-			}
+				this.setLocalStorage('users', this.usersList);
+			},
+			getLocalStorage(key) {
+				return JSON.parse(localStorage.getItem(key));
+			},
+			setLocalStorage(key, value) {
+				localStorage.setItem(key, JSON.stringify(value));
+			},
+			removeLocalStorage(key) {
+				localStorage.removeItem(key);
+			},
+
 		},
 		watch: {
 			$route: {
@@ -86,6 +97,13 @@
 					html.classList.add('page', 'page-' + to.name.toLowerCase());
 					body.classList.add('page-body');
 				},
+				immediate: true,
+			},
+			usersList: {
+				handler(newValue) {
+					this.setLocalStorage('users', newValue);
+				},
+				deep: true,
 				immediate: true,
 			}
 		},

--- a/src/components/Error.vue
+++ b/src/components/Error.vue
@@ -1,0 +1,53 @@
+<template>
+	<div class="error">
+		<span class="error__icon">
+			<i class="fas fa-exclamation-triangle"></i>
+		</span>
+		<div class="error__message">
+			<p>
+				{{ error.message }}
+			</p>
+		</div>
+		<div class="error__solution">
+			<p>
+				{{ error.solution }}
+			</p>
+		</div>
+	</div>
+</template>
+
+<script>
+	export default {
+		name: 'Error',
+		props: {
+			error: {
+				type: Object,
+				required: true
+			}
+		},
+	}
+</script>
+
+<style lang="scss" scoped>
+	.error {
+		min-height: 40vh;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		color: $color-error;
+
+		&__icon {
+			font-size: 7rem;
+		}
+
+		&__message {
+			font-size: 3.2rem;
+		}
+
+		&__solution {
+			font-size: 1.6rem;
+		}
+	}
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -27,10 +27,7 @@
 <script>
 	export default {
 		components: {
-		},
-		props: {
-			usersFetch: Array
-		},
+		}
 	};
 </script>
 

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -38,26 +38,11 @@
 				return this.usersList.find(user => user.username === this.username);
 			}
 		},
-		methods: {
-			selectUser() {
-				this.user.selected = true;
-				this.$parent.setLocalStorage('users', this.usersList);
-			},
-			unselectUser() {
-				this.usersList.map(user => user.selected = false);
-				this.$parent.setLocalStorage('users', this.usersList);
-			}
-		},
 		mounted() {
 			if (this.user === undefined) {
 				this.$router.push({ name: "users" });
-			} else {
-				this.selectUser();
 			}
-		},
-		destroyed() {
-			this.unselectUser();
-		},
+		}
 	};
 </script>
 

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -43,7 +43,7 @@
 				this.user.selected = true;
 			},
 			unselectUser() {
-				this.user.selected = false;
+				this.usersList.map(user => user.selected = false);
 			}
 		},
 		mounted() {

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -39,10 +39,7 @@
 			}
 		},
 		mounted() {
-			let rootUpdated = this.$route.params.username;
-			let rootFind = this.usersList.find(user => user.username === rootUpdated);
-
-			if (rootFind === undefined) {
+			if (this.user === undefined) {
 				this.$router.push({ name: "users" });
 			}
 		}

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -38,11 +38,24 @@
 				return this.usersList.find(user => user.username === this.username);
 			}
 		},
+		methods: {
+			selectUser() {
+				this.user.selected = true;
+			},
+			unselectUser() {
+				this.user.selected = false;
+			}
+		},
 		mounted() {
 			if (this.user === undefined) {
 				this.$router.push({ name: "users" });
+			} else {
+				this.selectUser();
 			}
-		}
+		},
+		destroyed() {
+			this.unselectUser();
+		},
 	};
 </script>
 

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -41,9 +41,11 @@
 		methods: {
 			selectUser() {
 				this.user.selected = true;
+				this.$parent.setLocalStorage('users', this.usersList);
 			},
 			unselectUser() {
 				this.usersList.map(user => user.selected = false);
+				this.$parent.setLocalStorage('users', this.usersList);
 			}
 		},
 		mounted() {

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -41,7 +41,7 @@
 				this.usersList.sort(() => Math.random() - 0.5);
 			},
 			async getUsers() {
-				await this.$parent.getUsers();
+				await this.$parent.setUsers();
 				this.usersList = this.usersFetch;
 			},
 			removeAllUsers() {

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -1,7 +1,12 @@
 <template>
 	<div class="page-main__inner">
 		<section class="page-section">
+			<error
+				v-if="usersList.length === 0"
+				:error="errorUsers"
+			/>
 			<users-list
+				v-else
 				:users="usersList"
 				:stateHidden="infoUserHidden"
 			/>
@@ -18,11 +23,13 @@
 <script>
 	import UsersList from "../components/UsersList.vue";
 	import UsersButtons from "../components/UsersButtons.vue";
+	import Error from "../components/Error.vue";
 
 	export default {
 		components: {
 			UsersList,
-			UsersButtons
+			UsersButtons,
+			Error
 		},
 		props: {
 			usersFetch: Array
@@ -31,6 +38,10 @@
 			return {
 				usersList: this.usersFetch,
 				infoUserHidden: false,
+				errorUsers: {
+					message: "Users not found",
+					solution: "Click on the button 'GET USERS'"
+				}
 			};
 		},
 		watch: {

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -52,6 +52,7 @@
 			},
 			orderUsers() {
 				this.usersList.sort(() => Math.random() - 0.5);
+				this.$parent.setLocalStorage('users', this.usersList);
 			},
 			async getUsers() {
 				this.removeAllUsers();

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -33,6 +33,13 @@
 				infoUserHidden: false,
 			};
 		},
+		watch: {
+			usersFetch(newVal, oldVal) {
+				if (newVal !== oldVal) {
+					this.usersList = newVal;
+				}
+			}
+		},
 		methods: {
 			hideInfoUser() {
 				this.infoUserHidden = !this.infoUserHidden;
@@ -41,13 +48,13 @@
 				this.usersList.sort(() => Math.random() - 0.5);
 			},
 			async getUsers() {
+				this.removeAllUsers();
 				await this.$parent.setUsers();
-				this.usersList = this.usersFetch;
 			},
 			removeAllUsers() {
 				this.usersList = [];
 			}
-		},
+		}
 	};
 </script>
 

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -38,6 +38,12 @@
 				if (newVal !== oldVal) {
 					this.usersList = newVal;
 				}
+			},
+			usersList(newVal, oldVal) {
+				if (newVal !== oldVal) {
+					this.usersList = newVal;
+					this.$parent.setLocalStorage("users", this.usersList);
+				}
 			}
 		},
 		methods: {


### PR DESCRIPTION
# hotfix(3.1.2): fix page reload losing user data with `Local Storage`

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | S | 12-04-2026 | 09-05-2026 |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [ ] New feature
- [ ] Improvement
- [ ] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

Fixed this issue:
`When reloading the browser page disappear the user/s data` #142

## 📋 Changes Made

### Version
- Bump version to `3.1.2`

## 🧪 Tests

- [x] Verify user data persists after page reload
- [x] Verify `Local Storage` correctly saves and restores user data

## 🔗 References

### Related Issues
- Closes #142