### PR TITLE
hotfix(4.2.2): remove `workflow_dispatch` from `check-node.yml` and `deploy.yml`

### DIFF
--- a/.github/workflows/check-node.yml
+++ b/.github/workflows/check-node.yml
@@ -6,7 +6,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  workflow_dispatch:
 jobs:
   check-node-build:
     name: 🧩 Build and test code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ name: 🚀 Deploy project in GitHub Pages
 on:
   push:
     branches: [ master ]
-  workflow_dispatch:
 jobs:
   gh-pages-deploy:
     name: 🧩 Deploying code to gh-pages branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-users",
-	"version": "4.2.1",
+	"version": "4.2.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-users",
-			"version": "4.2.1",
+			"version": "4.2.2",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "4.2.1",
+	"version": "4.2.2",
 	"private": true,
 	"name": "vue-users",
 	"description": "Vue app that get/set a list of random users from an API.",


### PR DESCRIPTION
# hotfix(4.2.2): remove `workflow_dispatch` from `check-node.yml` and `deploy.yml`

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P2 | XS | 12-04-2026 | 09-05-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [x] Documentation
- [x] CI/CD

## 📝 Summary

- Remove the `workflow_dispatch` trigger from GitHub Actions workflows (`check-node.yml` and `deploy.yml`) and updates the project version to 4.2.2.

## 📋 Changes Made

### CI/CD
- Remove `workflow_dispatch` from `.github/workflows/check-node.yml`
- Remove `workflow_dispatch` from `.github/workflows/deploy.yml`

### Version
- Bump version from `4.2.1` to `4.2.2` in `package.json` and `package-lock.json`

## 🧪 Tests

- [x] Verify build completes without errors:

```bash
npm run build
```
- [x] Verify the code follows the project's style guidelines
- [x] Perform a manual self-review of the code

## 📌 Notes

The `workflow_dispatch` was removed to prevent manual triggering of these workflows. They should only run automatically on push/PR events.

## 🔗 References

### Documentation
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

### Related Issues
- Closes #996