### PR TITLE
hotfix(4.2.3): update commitlint config to match standard across repositories

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -3,15 +3,10 @@ export default {
 		"@commitlint/config-conventional",
 	],
 	"rules": {
-		"header-max-length": [
-			2,
-			"always",
-			150,
-		],
 		"body-max-line-length": [
 			2,
 			"always",
-			1000,
+			10000,
 		],
 		"footer-leading-blank": [
 			0,
@@ -20,7 +15,28 @@ export default {
 		"footer-max-line-length": [
 			2,
 			"always",
-			1000,
+			10000,
+		],
+		"header-max-length": [
+			2,
+			"always",
+			150,
+		],
+		"type-enum": [
+			2,
+			"always",
+			[
+				"build",
+				"ci",
+				"docs",
+				"feat",
+				"fix",
+				"perf",
+				"refactor",
+				"revert",
+				"style",
+				"test",
+			],
 		],
 	},
 };

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -13,6 +13,10 @@ export default {
 			"always",
 			1000,
 		],
+		"footer-leading-blank": [
+			0,
+			"always",
+		],
 		"footer-max-line-length": [
 			2,
 			"always",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-users",
-	"version": "4.2.2",
+	"version": "4.2.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-users",
-			"version": "4.2.2",
+			"version": "4.2.3",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "4.2.2",
+	"version": "4.2.3",
 	"private": true,
 	"name": "vue-users",
 	"description": "Vue app that get/set a list of random users from an API.",


### PR DESCRIPTION
# hotfix(4.2.3): update commitlint config to match standard across repositories

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | XS | 12-04-2026 | 09-05-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

- Update the commitlint configuration to match the standard used across all repositories (like `beatrizsmerino`).

## 📋 Changes Made

### Configuration
- Update `body-max-line-length` rule from 1000 to 10000 characters
- Add `footer-leading-blank` rule disabled (value 0) to avoid warnings
- Update `footer-max-line-length` rule from 1000 to 10000 characters
- Keep `header-max-length` rule with 150 characters limit (reordered alphabetically)
- Add `type-enum` rule with standard conventional commit types: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`

### Version
- Bump version from `4.2.2` to `4.2.3` in `package.json` and `package-lock.json`

## 🧪 Tests

- [x] Verify build completes without errors:

```bash
npm run build
```
- [x] Verify the code follows the project's style guidelines
- [x] Perform a manual self-review of the code
- [x] Verify commits don't show `footer-leading-blank` warning

## 📌 Notes

The commitlint configuration was inconsistent with other repositories, causing warnings like `footer must have leading blank line [footer-leading-blank]` during commits.

## 🔗 References

### Related Issues
- Closes #1008