### PR TITLE
hotfix(4.5.3): simplify and align ignore files to a shared minimal format

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,5 @@
 # Add below any extra paths that should not be linted.
 
 
-# FOLDERS
-.nuxt
-dist
+# Build output
+dist/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,13 +1,11 @@
-# path/to/project/root/.eslintignore
-# /node_modules/* and /bower_components/* in the project root are ignored by default
+# ESLint defaults (no need to list):
+#   - Folders excluded automatically (node_modules/)
+#   - Non-JS files (CSS, images, fonts, *.md, LICENSE, etc.)
+#   - Files with unknown or extensionless types (.gitignore, .editorconfig)
+#
+# Add below any extra paths that should not be linted.
 
 
 # FOLDERS
-.git
 .nuxt
 dist
-
-# FILES
-.gitignore
-*.md
-LICENSE

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,7 @@
 # ESLint defaults (no need to list):
-#   - Folders excluded automatically (node_modules/)
-#   - Non-JS files (CSS, images, fonts, *.md, LICENSE, etc.)
-#   - Files with unknown or extensionless types (.gitignore, .editorconfig)
+#   - Folders excluded automatically (node_modules/, .git/)
+#   - Files with unknown or extensionless types (.gitignore, LICENSE, .editorconfig)
+#   - Non-JS files (CSS, images, fonts, *.md, etc.)
 #
 # Add below any extra paths that should not be linted.
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,25 @@
+# Dependencies
+node_modules/
+
+# OS
 .DS_Store
-node_modules
-/dist
+Thumbs.db
 
-# local env files
+# Logs
+*.log
+log/
+
+# Cache
+.npm
+.eslintcache
+.stylelintcache
+
+# Env
+.env
 .env.local
-.env.*.local
 
-# Log files
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+# Build output
+dist/
 
-# Editor directories and files
-.idea
-.vscode
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
+# Tests
+coverage/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,11 +1,11 @@
-# path/to/project/root/.prettierrc
-# /node_modules/* and /bower_components/* in the project root are ignored by default
+# Prettier defaults (no need to list):
+#   - Folders excluded automatically (node_modules/, .git/)
+#   - Files with unknown or extensionless types (.gitignore, LICENSE, .editorconfig)
+#   - Binary files (images, fonts, etc.)
+#
+# Add below any extra paths that should not be formatted.
 
 
 # FOLDERS
-.git
 .nuxt
 dist
-
-# FILES
-.gitignore

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,7 @@
 # Prettier defaults (no need to list):
 #   - Folders excluded automatically (node_modules/, .git/)
 #   - Files with unknown or extensionless types (.gitignore, LICENSE, .editorconfig)
-#   - Binary files (images, fonts, etc.)
+#   - Non-formattable files (images, fonts, etc.)
 #
 # Add below any extra paths that should not be formatted.
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,5 @@
 # Add below any extra paths that should not be formatted.
 
 
-# FOLDERS
-.nuxt
-dist
+# Build output
+dist/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,7 +1,7 @@
 # Stylelint defaults (no need to list):
-#   - Folders excluded automatically (node_modules/)
-#   - Non-CSS files (JS, images, fonts, etc.)
+#   - Folders excluded automatically (node_modules/, .git/)
 #   - Files with unknown or extensionless types (.gitignore, LICENSE, .editorconfig)
+#   - Non-CSS files (JS, images, fonts, etc.)
 #
 # Add below any extra paths that should not be linted.
 

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -6,5 +6,5 @@
 # Add below any extra paths that should not be linted.
 
 
-# FOLDERS
-dist
+# Build output
+dist/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,10 +1,10 @@
-# path/to/project/root/.stylelint.config.js
-# /node_modules/* and /bower_components/* in the project root are ignored by default
+# Stylelint defaults (no need to list):
+#   - Folders excluded automatically (node_modules/)
+#   - Non-CSS files (JS, images, fonts, etc.)
+#   - Files with unknown or extensionless types (.gitignore, LICENSE, .editorconfig)
+#
+# Add below any extra paths that should not be linted.
 
 
 # FOLDERS
-.git
 dist
-
-# FILES
-.gitignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-users",
-	"version": "4.5.2",
+	"version": "4.5.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-users",
-			"version": "4.5.2",
+			"version": "4.5.3",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "4.5.2",
+	"version": "4.5.3",
 	"private": true,
 	"name": "vue-users",
 	"description": "Vue app that get/set a list of random users from an API.",


### PR DESCRIPTION
# hotfix(4.5.3): simplify and align ignore files to a shared minimal format

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 4h | P2 | M | 14-04-2026 | 09-05-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change
- [x] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [x] Documentation
- [ ] CI/CD

## 📝 Summary

- Hotfix release that simplifies `.gitignore`, `.prettierignore`, `.eslintignore` and `.stylelintignore` to a shared minimal format with a unified header structure

## 📋 Changes Made

### Configuration

#### `.gitignore`
- Simplify to minimum viable ignore rules

#### `.prettierignore`
- Update header and remove entries already ignored by default
- Restructure entries under `# Build output` block

#### `.eslintignore`
- Update header and remove entries already ignored by default
- Restructure entries under `# Build output` block

#### `.stylelintignore`
- Update header and remove entries already ignored by default
- Restructure entries under `# Build output` block

#### Header unification
- Unify header structure across `.prettierignore`, `.eslintignore` and `.stylelintignore`

### Version
- Bump version from `4.5.2` to `4.5.3`

## 🧪 Tests
- [x] Verify linting passes with no errors and ignored folders are respected:

```bash
npm run lint
```

## 🔗 References

### Related Issues
- Closes #1170
- Closes #1171
- Closes #1172
- Closes #1173