### PR TITLE
hotfix(4.5.4): update `package-lock.json` and `packages/*/package.json` in `update-node-npm.yml`

### DIFF
--- a/.github/workflows/update-node-npm.yml
+++ b/.github/workflows/update-node-npm.yml
@@ -12,6 +12,7 @@
 # Files updated by this workflow:
 # - .nvmrc
 # - package.json (engines.node and engines.npm)
+# - packages/*/package.json (engines.node and engines.npm)
 # - .github/workflows/check-node.yml (matrix node-version)
 # - .github/workflows/deploy.yml (node-version)
 
@@ -230,6 +231,16 @@ jobs:
 
           echo "Updated package.json engines"
           cat package.json | jq '.engines'
+
+      - name: 📝 Update workspaces package.json engines
+        if: steps.check-update.outputs.update_needed == 'true'
+        run: |
+          shopt -s nullglob
+          for ws_pkg in packages/*/package.json; do
+            jq --tab '.engines.node = "${{ steps.node-versions.outputs.latest_version }}" | .engines.npm = "${{ steps.node-versions.outputs.npm_version }}"' "$ws_pkg" > "$ws_pkg.tmp"
+            mv "$ws_pkg.tmp" "$ws_pkg"
+            echo "Updated $ws_pkg"
+          done
 
       - name: 📝 Update check-node.yml matrix
         if: steps.check-update.outputs.update_needed == 'true' && steps.current-versions.outputs.has_node_yml == 'true'

--- a/.github/workflows/update-node-npm.yml
+++ b/.github/workflows/update-node-npm.yml
@@ -13,6 +13,7 @@
 # - .nvmrc
 # - package.json (engines.node and engines.npm)
 # - packages/*/package.json (engines.node and engines.npm)
+# - package-lock.json (engines for root and workspace entries)
 # - .github/workflows/check-node.yml (matrix node-version)
 # - .github/workflows/deploy.yml (node-version)
 
@@ -241,6 +242,18 @@ jobs:
             mv "$ws_pkg.tmp" "$ws_pkg"
             echo "Updated $ws_pkg"
           done
+
+      - name: 📝 Update package-lock.json engines
+        if: steps.check-update.outputs.update_needed == 'true' && hashFiles('package-lock.json') != ''
+        run: |
+          jq --tab '.packages |= with_entries(
+            if (.key == "" or (.key | startswith("packages/")))
+            then .value.engines.node = "${{ steps.node-versions.outputs.latest_version }}" | .value.engines.npm = "${{ steps.node-versions.outputs.npm_version }}"
+            else .
+            end
+          )' package-lock.json > package-lock.json.tmp
+          mv package-lock.json.tmp package-lock.json
+          echo "Updated package-lock.json engines"
 
       - name: 📝 Update check-node.yml matrix
         if: steps.check-update.outputs.update_needed == 'true' && steps.current-versions.outputs.has_node_yml == 'true'

--- a/.github/workflows/update-node-npm.yml
+++ b/.github/workflows/update-node-npm.yml
@@ -289,6 +289,10 @@ jobs:
             - Update `.nvmrc` file: v${{ steps.current-versions.outputs.current_node }} → v${{ steps.node-versions.outputs.latest_version }}
             - Update `package.json` file in `engines.node`: ${{ steps.current-versions.outputs.current_node }} → ${{ steps.node-versions.outputs.latest_version }}
             - Update `package.json` file in `engines.npm`: ${{ steps.current-versions.outputs.current_npm }} → ${{ steps.node-versions.outputs.npm_version }}
+            - Update `packages/*/package.json` files in `engines.node`: ${{ steps.current-versions.outputs.current_node }} → ${{ steps.node-versions.outputs.latest_version }}
+            - Update `packages/*/package.json` files in `engines.npm`: ${{ steps.current-versions.outputs.current_npm }} → ${{ steps.node-versions.outputs.npm_version }}
+            - Update `package-lock.json` in `engines.node`: ${{ steps.current-versions.outputs.current_node }} → ${{ steps.node-versions.outputs.latest_version }}
+            - Update `package-lock.json` in `engines.npm`: ${{ steps.current-versions.outputs.current_npm }} → ${{ steps.node-versions.outputs.npm_version }}
             - Update `check-node.yml` file in matrix: ${{ steps.current-versions.outputs.current_matrix }} → ${{ steps.node-versions.outputs.matrix }}
             - Update `deploy.yml` file in node-version: ${{ steps.node-versions.outputs.latest_version }}
           title: "build(deps): update `node@${{ steps.node-versions.outputs.latest_version }}` and `npm@${{ steps.node-versions.outputs.npm_version }}` versions"
@@ -318,6 +322,10 @@ jobs:
             - Update `.nvmrc` file: `v${{ steps.current-versions.outputs.current_node }}` → `v${{ steps.node-versions.outputs.latest_version }}`
             - Update `package.json` file in `engines.node`: `${{ steps.current-versions.outputs.current_node }}` → `${{ steps.node-versions.outputs.latest_version }}`
             - Update `package.json` file in `engines.npm`: `${{ steps.current-versions.outputs.current_npm }}` → `${{ steps.node-versions.outputs.npm_version }}`
+            - Update `packages/*/package.json` files in `engines.node`: `${{ steps.current-versions.outputs.current_node }}` → `${{ steps.node-versions.outputs.latest_version }}`
+            - Update `packages/*/package.json` files in `engines.npm`: `${{ steps.current-versions.outputs.current_npm }}` → `${{ steps.node-versions.outputs.npm_version }}`
+            - Update `package-lock.json` in `engines.node`: `${{ steps.current-versions.outputs.current_node }}` → `${{ steps.node-versions.outputs.latest_version }}`
+            - Update `package-lock.json` in `engines.npm`: `${{ steps.current-versions.outputs.current_npm }}` → `${{ steps.node-versions.outputs.npm_version }}`
             - Update `check-node.yml` file in matrix: `${{ steps.current-versions.outputs.current_matrix }}` → `${{ steps.node-versions.outputs.matrix }}`
             - Update `deploy.yml` file in node-version: `${{ steps.node-versions.outputs.latest_version }}`
 
@@ -374,6 +382,20 @@ jobs:
             NODE_YML_ICON="❌ Not found"
           fi
 
+          shopt -s nullglob
+          WS_PKGS=(packages/*/package.json)
+          if [ ${#WS_PKGS[@]} -gt 0 ]; then
+            WS_PKG_ICON="✅ Found (${#WS_PKGS[@]})"
+          else
+            WS_PKG_ICON="❌ Not found"
+          fi
+
+          if [ -f package-lock.json ]; then
+            LOCKFILE_ICON="✅ Found"
+          else
+            LOCKFILE_ICON="❌ Not found"
+          fi
+
           if [ -f .github/workflows/deploy.yml ]; then
             DEPLOY_YML_ICON="✅ Found"
           else
@@ -402,6 +424,8 @@ jobs:
           | \`.noderc.json\` | ${CONFIG_ICON} | Version limit configuration |
           | \`.nvmrc\` | ${NVMRC_ICON} | Node version for nvm |
           | \`package.json\` | ${ENGINES_ICON} | Engines of node and npm |
+          | \`packages/*/package.json\` | ${WS_PKG_ICON} | Engines of node and npm in workspaces |
+          | \`package-lock.json\` | ${LOCKFILE_ICON} | Engines for root and workspace entries |
           | \`check-node.yml\` | ${NODE_YML_ICON} | CI workflow matrix |
           | \`deploy.yml\` | ${DEPLOY_YML_ICON} | Deploy workflow node-version |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-users",
-	"version": "4.5.3",
+	"version": "4.5.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-users",
-			"version": "4.5.3",
+			"version": "4.5.4",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "4.5.3",
+	"version": "4.5.4",
 	"private": true,
 	"name": "vue-users",
 	"description": "Vue app that get/set a list of random users from an API.",


### PR DESCRIPTION
# hotfix(4.5.4): update `package-lock.json` and `packages/*/package.json` in `update-node-npm.yml`

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 2h | P0 | S | 19-04-2026 | 09-05-2026 |

## 📸 Screenshots
| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change
- [x] Bug fix
- [x] CI/CD

## 📝 Summary
- Add a new step to `update-node-npm.yml` that updates `engines.node` and `engines.npm` in every workspace `packages/*/package.json` (Phase 1) — runs as a no-op here (no workspaces) but kept so the workflow can be reused as a single template in future monorepo setups
- Add a new step that updates the `engines` block of the root entry (`packages[""]`) inside `package-lock.json` (Phase 2)
- Reflect both new files in the workflow's user-visible places: `commit-message` template, `body` template and the `📁 Project Files` table of `📊 Summary` (Phase 3)
- Bump `package.json` and `package-lock.json` version to `4.5.4`

## 📋 Changes Made

### Bug Fixes
- The previous workflow updated `.nvmrc`, the root `package.json` and `check-node.yml` but skipped `package-lock.json` — after every bump, the lockfile's `engines` block drifted out of sync with `package.json`, and `npm install`/`npm ci` would later rewrite it, polluting future PRs with unrelated lockfile changes
- Workflow now updates the lockfile alongside the existing files, keeping it consistent
- The new `📝 Update workspaces package.json engines` step is included so the workflow file can be maintained as a single template; in this single-package repo the step is a no-op (the for loop iterates zero times)

## 🧪 Tests
- [x] Trigger `workflow_dispatch` from `hotfix/4.5.4` and verify the run ends successfully
- [x] Verify the workspace step iterates zero times (no `packages/*/package.json` to update)
- [x] Verify the lockfile filter touches only the root entry (`packages[""]`)
- [x] Verify `.nvmrc`, root `package.json` `engines` and `check-node.yml` matrix are updated as before
- [x] Verify the `📁 Project Files` table in `📊 Summary` shows the new rows for `packages/*/package.json` (❌ Not found) and `package-lock.json` (✅ Found)

## 📌 Notes
- Other workflow robustness improvements are intentionally NOT part of this hotfix — they are non-urgent and will be handled in separate issues to keep this scope minimal

## 🔗 References

### Related Issues
- Closes #1181